### PR TITLE
Upgrade to Vert.x 3.6.3 and utilize non-threaded worker verticles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ configurations.all {
 }
 
 dependencies {
-    compile 'io.vertx:vertx-web:3.5.3'
-    compile 'io.vertx:vertx-hazelcast:3.5.3'
+    compile 'io.vertx:vertx-web:3.6.3'
+    compile 'io.vertx:vertx-hazelcast:3.6.3'
     compileOnly('omero:blitz:5.4.10-ice36-b105') {
         exclude group: 'org.testng', module: 'testng'
     }

--- a/src/dist/hazelcast.xml.example
+++ b/src/dist/hazelcast.xml.example
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+    The default Hazelcast configuration. This is used when no hazelcast.xml is present.
+    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.8.xsd
+    or the documentation at https://hazelcast.org/documentation/
+-->
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <group>
+        <name>dev</name>
+        <password>dev-pass</password>
+    </group>
+    <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+    <network>
+        <port auto-increment="true" port-count="100">5701</port>
+        <outbound-ports>
+            <!--
+            Allowed port range when connecting to other nodes.
+            0 or * means use system provided port.
+            -->
+            <ports>0</ports>
+        </outbound-ports>
+        <join>
+            <multicast enabled="true">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="false">
+                <interface>127.0.0.1</interface>
+                <member-list>
+                    <member>127.0.0.1</member>
+                </member-list>
+            </tcp-ip>
+            <aws enabled="false">
+                <access-key>my-access-key</access-key>
+                <secret-key>my-secret-key</secret-key>
+                <!--optional, default is us-east-1 -->
+                <region>us-west-1</region>
+                <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+                <host-header>ec2.amazonaws.com</host-header>
+                <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+                <security-group-name>hazelcast-sg</security-group-name>
+                <tag-key>type</tag-key>
+                <tag-value>hz-nodes</tag-value>
+            </aws>
+            <discovery-strategies>
+            </discovery-strategies>
+        </join>
+        <interfaces enabled="false">
+            <interface>10.10.1.*</interface>
+        </interfaces>
+        <ssl enabled="false"/>
+        <socket-interceptor enabled="false"/>
+        <symmetric-encryption enabled="false">
+            <!--
+               encryption algorithm such as
+               DES/ECB/PKCS5Padding,
+               PBEWithMD5AndDES,
+               AES/CBC/PKCS5Padding,
+               Blowfish,
+               DESede
+            -->
+            <algorithm>PBEWithMD5AndDES</algorithm>
+            <!-- salt value to use when generating the secret key -->
+            <salt>thesalt</salt>
+            <!-- pass phrase to use when generating the secret key -->
+            <password>thepass</password>
+            <!-- iteration count to use when generating the secret key -->
+            <iteration-count>19</iteration-count>
+        </symmetric-encryption>
+    </network>
+    <partition-group enabled="false"/>
+    <executor-service name="default">
+        <pool-size>16</pool-size>
+        <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+        <queue-capacity>0</queue-capacity>
+    </executor-service>
+    <queue name="default">
+        <!--
+            Maximum size of the queue. When a JVM's local queue size reaches the maximum,
+            all put/offer operations will get blocked until the queue size
+            of the JVM goes down below the maximum.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size>0</max-size>
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. 0 means no backup.
+        -->
+        <backup-count>1</backup-count>
+
+        <!--
+            Number of async backups. 0 means no backup.
+        -->
+        <async-backup-count>0</async-backup-count>
+
+        <empty-queue-ttl>-1</empty-queue-ttl>
+    </queue>
+    <map name="default">
+        <!--
+           Data type that will be used for storing recordMap.
+           Possible values:
+           BINARY (default): keys and values will be stored as binary data
+           OBJECT : values will be stored in their object forms
+           NATIVE : values will be stored in non-heap region of JVM
+        -->
+        <in-memory-format>BINARY</in-memory-format>
+
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. 0 means no backup.
+        -->
+        <backup-count>1</backup-count>
+        <!--
+            Number of async backups. 0 means no backup.
+        -->
+        <async-backup-count>0</async-backup-count>
+        <!--
+			Maximum number of seconds for each entry to stay in the map. Entries that are
+			older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+			will get automatically evicted from the map.
+			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+		-->
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <!--
+			Maximum number of seconds for each entry to stay idle in the map. Entries that are
+			idle(not touched) for more than <max-idle-seconds> will get
+			automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+		-->
+        <max-idle-seconds>0</max-idle-seconds>
+        <!--
+            Valid values are:
+            NONE (no eviction),
+            LRU (Least Recently Used),
+            LFU (Least Frequently Used).
+            NONE is the default.
+        -->
+        <eviction-policy>NONE</eviction-policy>
+        <!--
+            Maximum size of the map. When max size is reached,
+            map is evicted based on the policy defined.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size policy="PER_NODE">0</max-size>
+        <!--
+            `eviction-percentage` property is deprecated and will be ignored when it is set.
+
+            As of version 3.7, eviction mechanism changed.
+            It uses a probabilistic algorithm based on sampling. Please see documentation for further details
+        -->
+        <eviction-percentage>25</eviction-percentage>
+        <!--
+            `min-eviction-check-millis` property is deprecated  and will be ignored when it is set.
+
+            As of version 3.7, eviction mechanism changed.
+            It uses a probabilistic algorithm based on sampling. Please see documentation for further details
+        -->
+        <min-eviction-check-millis>100</min-eviction-check-millis>
+        <!--
+            While recovering from split-brain (network partitioning),
+            map entries in the small cluster will merge into the bigger cluster
+            based on the policy set here. When an entry merge into the
+            cluster, there might an existing entry with the same key already.
+            Values of these entries might be different for that same key.
+            Which value should be set for the key? Conflict is resolved by
+            the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+            There are built-in merge policies such as
+            com.hazelcast.map.merge.PassThroughMergePolicy; entry will be overwritten if merging entry exists for the key.
+            com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+            com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+            com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+        -->
+        <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
+
+        <!--
+           Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
+           Possible Values:
+                        NEVER: Never cache deserialized object
+                        INDEX-ONLY: Caches values only when they are inserted into an index.
+                        ALWAYS: Always cache deserialized values.
+        -->
+        <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>
+
+    </map>
+
+    <multimap name="default">
+        <backup-count>1</backup-count>
+        <value-collection-type>SET</value-collection-type>
+    </multimap>
+
+    <list name="default">
+        <backup-count>1</backup-count>
+    </list>
+
+    <set name="default">
+        <backup-count>1</backup-count>
+    </set>
+
+    <jobtracker name="default">
+        <max-thread-size>0</max-thread-size>
+        <!-- Queue size 0 means number of partitions * 2 -->
+        <queue-size>0</queue-size>
+        <retry-count>0</retry-count>
+        <chunk-size>1000</chunk-size>
+        <communicate-stats>true</communicate-stats>
+        <topology-changed-strategy>CANCEL_RUNNING_OPERATION</topology-changed-strategy>
+    </jobtracker>
+
+    <semaphore name="default">
+        <initial-permits>0</initial-permits>
+        <backup-count>1</backup-count>
+        <async-backup-count>0</async-backup-count>
+    </semaphore>
+
+    <reliable-topic name="default">
+        <read-batch-size>10</read-batch-size>
+        <topic-overload-policy>BLOCK</topic-overload-policy>
+        <statistics-enabled>true</statistics-enabled>
+    </reliable-topic>
+
+    <ringbuffer name="default">
+        <capacity>10000</capacity>
+        <backup-count>1</backup-count>
+        <async-backup-count>0</async-backup-count>
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <in-memory-format>BINARY</in-memory-format>
+    </ringbuffer>
+
+    <serialization>
+        <portable-version>0</portable-version>
+    </serialization>
+
+    <services enable-defaults="true"/>
+
+    <lite-member enabled="false"/>
+
+</hazelcast>
+

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneSimpleWork.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneSimpleWork.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2019 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.glencoesoftware.omero.ms.backbone;
 
 import io.vertx.core.eventbus.Message;

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
@@ -110,6 +110,8 @@ public class BackboneVerticle extends AbstractVerticle {
                 GET_RENDERING_SETTINGS_EVENT, this::getRenderingSettings);
         vertx.eventBus().<JsonObject>consumer(
                 GET_PIXELS_DESCRIPTION_EVENT, this::getPixelsDescription);
+
+        future.complete();
     }
 
     private void handleMessageWithJob(BackboneSimpleWork job) {

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
@@ -96,9 +96,9 @@ public class BackboneVerticle extends AbstractVerticle {
     public void start() {
         EventBus eventBus = vertx.eventBus();
 
-        eventBus.<String>consumer(
-            IS_SESSION_VALID_EVENT, new Handler<Message<String>>() {
-                public void handle(Message<String> event) {
+        eventBus.<JsonObject>consumer(
+            IS_SESSION_VALID_EVENT, new Handler<Message<JsonObject>>() {
+                public void handle(Message<JsonObject> event) {
                     isSessionValid(event);
                 };
             }
@@ -174,9 +174,8 @@ public class BackboneVerticle extends AbstractVerticle {
         }
     }
 
-    private void isSessionValid(Message<String> message) {
-        String sessionKey =
-                new JsonObject(message.body()).getString("sessionKey");
+    private void isSessionValid(Message<JsonObject> message) {
+        String sessionKey = message.body().getString("sessionKey");
         try {
             message.reply(new Boolean(sessionManager.find(sessionKey) != null));
         } catch (Exception e) {

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
@@ -24,11 +24,11 @@ import java.util.List;
 
 import org.hibernate.Session;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import ome.api.IPixels;
@@ -49,6 +49,11 @@ import omero.util.IceMapper;
 
 /**
  * Main entry point for the OMERO microservice architecture backbone verticle.
+ * <b>NOTE:</b> As this verticle is being instantiated by Spring 3 inside the
+ * OMERO server it <b>CANNOT</b> contain any Java 8+ lambda expressions in
+ * directly accessible code paths.  If you are seeing
+ * {@link ArrayIndexOutOfBoundsException}'s thrown from Spring ASM during bean
+ * instantiation, check for lambda expressions.
  * @author Chris Allan <callan@glencoesoftware.com>
  *
  */
@@ -75,9 +80,6 @@ public class BackboneVerticle extends AbstractVerticle {
     public static final String GET_PIXELS_DESCRIPTION_EVENT =
             "omero.get_pixels_description";
 
-    /** OMERO server Spring application context. */
-    private ApplicationContext context;
-
     private final Executor executor;
 
     private final SessionManager sessionManager;
@@ -85,33 +87,62 @@ public class BackboneVerticle extends AbstractVerticle {
     private final DetailsContextsFilter contextsFilter =
             new DetailsContextsFilter();
 
-    BackboneVerticle(Executor executor, SessionManager sessionManager) {
+    public BackboneVerticle() {
+        this.executor = null;
+        this.sessionManager = null;
+    }
+
+    public BackboneVerticle(Executor executor, SessionManager sessionManager) {
         this.executor = executor;
         this.sessionManager = sessionManager;
     }
 
-    /**
-     * Entry point method which starts the server event loop.
-     * @param args Command line arguments.
-     */
     @Override
-    public void start(Future<Void> future) {
-        log.info("Starting verticle");
+    public void start() {
+        EventBus eventBus = vertx.eventBus();
 
-        vertx.eventBus().<String>consumer(
-                IS_SESSION_VALID_EVENT, this::isSessionValid);
-        vertx.eventBus().<JsonObject>consumer(
-                CAN_READ_EVENT, this::canRead);
-        vertx.eventBus().<JsonObject>consumer(
-                GET_OBJECT_EVENT, this::getObject);
-        vertx.eventBus().<JsonObject>consumer(
-                GET_ALL_ENUMERATIONS_EVENT, this::getAllEnumerations);
-        vertx.eventBus().<JsonObject>consumer(
-                GET_RENDERING_SETTINGS_EVENT, this::getRenderingSettings);
-        vertx.eventBus().<JsonObject>consumer(
-                GET_PIXELS_DESCRIPTION_EVENT, this::getPixelsDescription);
-
-        future.complete();
+        eventBus.<String>consumer(
+            IS_SESSION_VALID_EVENT, new Handler<Message<String>>() {
+                public void handle(Message<String> event) {
+                    isSessionValid(event);
+                };
+            }
+        );
+        eventBus.<JsonObject>consumer(
+            CAN_READ_EVENT, new Handler<Message<JsonObject>>() {
+                public void handle(Message<JsonObject> event) {
+                    canRead(event);
+                };
+            }
+        );
+        eventBus.<JsonObject>consumer(
+            GET_OBJECT_EVENT, new Handler<Message<JsonObject>>() {
+                public void handle(Message<JsonObject> event) {
+                    getObject(event);
+                };
+            }
+        );
+        eventBus.<JsonObject>consumer(
+            GET_ALL_ENUMERATIONS_EVENT, new Handler<Message<JsonObject>>() {
+                public void handle(Message<JsonObject> event) {
+                    getAllEnumerations(event);
+                };
+            }
+        );
+        eventBus.<JsonObject>consumer(
+            GET_RENDERING_SETTINGS_EVENT, new Handler<Message<JsonObject>>() {
+                public void handle(Message<JsonObject> event) {
+                    getRenderingSettings(event);
+                };
+            }
+        );
+        eventBus.<JsonObject>consumer(
+            GET_PIXELS_DESCRIPTION_EVENT, new Handler<Message<JsonObject>>() {
+                public void handle(Message<JsonObject> event) {
+                    getPixelsDescription(event);
+                };
+            }
+        );
     }
 
     private void handleMessageWithJob(BackboneSimpleWork job) {

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
@@ -87,11 +87,6 @@ public class BackboneVerticle extends AbstractVerticle {
     private final DetailsContextsFilter contextsFilter =
             new DetailsContextsFilter();
 
-    public BackboneVerticle() {
-        this.executor = null;
-        this.sessionManager = null;
-    }
-
     public BackboneVerticle(Executor executor, SessionManager sessionManager) {
         this.executor = executor;
         this.sessionManager = sessionManager;

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/DetailsContextsFilter.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/DetailsContextsFilter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2019 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.glencoesoftware.omero.ms.backbone;
 
 import org.slf4j.LoggerFactory;
@@ -9,6 +27,8 @@ import ome.util.Filterable;
 /**
  * Strips <code>Contexts</code> from {@link Details} instances in the object
  * graph so that the graph can be used with Java serialization.
+ * @author Chris Allan <callan@glencoesoftware.com>
+ *
  */
 public class DetailsContextsFilter extends ContextFilter {
 

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/OmeroVerticleFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/OmeroVerticleFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.omero.ms.backbone;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import io.vertx.core.Verticle;
+import io.vertx.core.spi.VerticleFactory;
+
+/**
+ * Spring backed OMERO verticle factory.  Implementation cribbed from the
+ * <code>SpringVerticleFactory</code> of the Vert.x Spring worker example.
+ * @author Chris Allan <callan@glencoesoftware.com>
+ *
+ */
+public class OmeroVerticleFactory
+        implements VerticleFactory, ApplicationContextAware {
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public boolean blockingCreate() {
+      // Usually verticle instantiation is fast but since our verticles are
+      // Spring Beans, they might depend on other beans/resources which are
+      // slow to build/lookup.
+      return true;
+    }
+
+    @Override
+    public String prefix() {
+      return "omero";
+    }
+
+    @Override
+    public Verticle createVerticle(
+            String verticleName, ClassLoader classLoader)
+                    throws Exception {
+      return (Verticle) applicationContext.getBean(
+              VerticleFactory.removePrefix(verticleName));
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext)
+            throws BeansException {
+      this.applicationContext = applicationContext;
+    }
+
+  }

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/QueryVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/QueryVerticle.java
@@ -27,7 +27,9 @@ import java.util.Map;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
@@ -90,6 +92,25 @@ public class QueryVerticle extends AbstractVerticle {
         });
     }
 
+    private <T> void ifFailed(
+            HttpServerResponse response, AsyncResult<Message<T>> result) {
+        Throwable t = result.cause();
+        int statusCode = 404;
+        if (t instanceof ReplyException) {
+            statusCode = ((ReplyException) t).failureCode();
+        }
+        log.error("Request failed", t);
+        response.setStatusCode(statusCode);
+    }
+
+    private <T> T deserialize(AsyncResult<Message<byte[]>> result)
+            throws IOException, ClassNotFoundException {
+        ByteArrayInputStream bais =
+                new ByteArrayInputStream(result.result().body());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        return (T) ois.readObject();
+    }
+
     private void isSessionValid(RoutingContext event) {
         final HttpServerRequest request = event.request();
         final HttpServerResponse response = event.response();
@@ -103,13 +124,7 @@ public class QueryVerticle extends AbstractVerticle {
             String s = "";
             try {
                 if (result.failed()) {
-                    Throwable t = result.cause();
-                    int statusCode = 404;
-                    if (t instanceof ReplyException) {
-                        statusCode = ((ReplyException) t).failureCode();
-                    }
-                    log.error("Request failed", t);
-                    response.setStatusCode(statusCode);
+                    ifFailed(response, result);
                     return;
                 }
                 response.headers().set("Content-Type", "text/plain");
@@ -139,13 +154,7 @@ public class QueryVerticle extends AbstractVerticle {
             String s = "";
             try {
                 if (result.failed()) {
-                    Throwable t = result.cause();
-                    int statusCode = 404;
-                    if (t instanceof ReplyException) {
-                        statusCode = ((ReplyException) t).failureCode();
-                    }
-                    log.error("Request failed", t);
-                    response.setStatusCode(statusCode);
+                    ifFailed(response, result);
                     return;
                 }
                 response.headers().set("Content-Type", "text/plain");
@@ -175,20 +184,11 @@ public class QueryVerticle extends AbstractVerticle {
             String s = "";
             try {
                 if (result.failed()) {
-                    Throwable t = result.cause();
-                    int statusCode = 404;
-                    if (t instanceof ReplyException) {
-                        statusCode = ((ReplyException) t).failureCode();
-                    }
-                    log.error("Request failed", t);
-                    response.setStatusCode(statusCode);
+                    ifFailed(response, result);
                     return;
                 }
                 response.headers().set("Content-Type", "text/plain");
-                ByteArrayInputStream bais =
-                        new ByteArrayInputStream(result.result().body());
-                ObjectInputStream ois = new ObjectInputStream(bais);
-                s = ois.readObject().toString();
+                s = deserialize(result).toString();
             } catch (IOException | ClassNotFoundException e) {
                 log.error("Exception while decoding object in response", e);
             } finally {
@@ -214,20 +214,11 @@ public class QueryVerticle extends AbstractVerticle {
             String s = "";
             try {
                 if (result.failed()) {
-                    Throwable t = result.cause();
-                    int statusCode = 404;
-                    if (t instanceof ReplyException) {
-                        statusCode = ((ReplyException) t).failureCode();
-                    }
-                    log.error("Request failed", t);
-                    response.setStatusCode(statusCode);
+                    ifFailed(response, result);
                     return;
                 }
                 response.headers().set("Content-Type", "text/plain");
-                ByteArrayInputStream bais =
-                        new ByteArrayInputStream(result.result().body());
-                ObjectInputStream ois = new ObjectInputStream(bais);
-                s = ois.readObject().toString();
+                s = deserialize(result).toString();
             } catch (IOException | ClassNotFoundException e) {
                 log.error("Exception while decoding object in response", e);
             } finally {
@@ -254,20 +245,11 @@ public class QueryVerticle extends AbstractVerticle {
             String s = "";
             try {
                 if (result.failed()) {
-                    Throwable t = result.cause();
-                    int statusCode = 404;
-                    if (t instanceof ReplyException) {
-                        statusCode = ((ReplyException) t).failureCode();
-                    }
-                    log.error("Request failed", t);
-                    response.setStatusCode(statusCode);
+                    ifFailed(response, result);
                     return;
                 }
                 response.headers().set("Content-Type", "text/plain");
-                ByteArrayInputStream bais =
-                        new ByteArrayInputStream(result.result().body());
-                ObjectInputStream ois = new ObjectInputStream(bais);
-                s = ois.readObject().toString();
+                s = deserialize(result).toString();
             } catch (IOException | ClassNotFoundException e) {
                 log.error("Exception while decoding object in response", e);
             } finally {
@@ -293,20 +275,11 @@ public class QueryVerticle extends AbstractVerticle {
             String s = "";
             try {
                 if (result.failed()) {
-                    Throwable t = result.cause();
-                    int statusCode = 404;
-                    if (t instanceof ReplyException) {
-                        statusCode = ((ReplyException) t).failureCode();
-                    }
-                    log.error("Request failed", t);
-                    response.setStatusCode(statusCode);
+                    ifFailed(response, result);
                     return;
                 }
                 response.headers().set("Content-Type", "text/plain");
-                ByteArrayInputStream bais =
-                        new ByteArrayInputStream(result.result().body());
-                ObjectInputStream ois = new ObjectInputStream(bais);
-                Pixels pixels = (Pixels) ois.readObject();
+                Pixels pixels = deserialize(result);
                 Image image = pixels.getImage();
                 s = String.format(
                         "%s;%s;Series:%s", pixels, image, image.getSeries());

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/QueryVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/QueryVerticle.java
@@ -36,7 +36,6 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.CookieHandler;
 import ome.model.core.Image;
 import ome.model.core.Pixels;
 
@@ -60,9 +59,6 @@ public class QueryVerticle extends AbstractVerticle {
         log.info("Starting verticle");
         HttpServer server = vertx.createHttpServer();
         Router router = Router.router(vertx);
-
-        // Cookie handler so we can pick up the OMERO.web session
-        router.route().handler(CookieHandler.create());
 
         // Thumbnail request handlers
         router.get("/api/:sessionKey/isSessionValid")

--- a/src/main/resources/ome/services/blitz-BackboneService.xml
+++ b/src/main/resources/ome/services/blitz-BackboneService.xml
@@ -6,10 +6,20 @@
         Defines the beans for microservices.
   </description>
 
-  <bean name="omero-ms-backbone" class="com.glencoesoftware.omero.ms.backbone.BackboneService">
+  <bean id="omero-ms-backbone-verticlefactory"
+        class="com.glencoesoftware.omero.ms.backbone.OmeroVerticleFactory"/>
+
+  <bean id="omero-ms-backbone"
+        class="com.glencoesoftware.omero.ms.backbone.BackboneService">
+    <constructor-arg ref="preferenceContext"/>
+    <constructor-arg ref="omero-ms-backbone-verticlefactory"/>
+  </bean>
+
+  <bean id="omero-ms-backbone-verticle"
+        class="com.glencoesoftware.omero.ms.backbone.BackboneVerticle"
+        singleton="false">
     <constructor-arg ref="executor"/>
     <constructor-arg ref="sessionManager"/>
-    <constructor-arg ref="preferenceContext"/>
   </bean>
 
 </beans>


### PR DESCRIPTION
As of Vert.x 3.6.0 threaded worker verticles are deprecated (eclipse-vertx/vert.x#2702). They will be removed in Vert.x 4.0.0. We previously used the threaded style because it allowed us to simply instantiate the verticle ourselves, provide constructor arguments during instantiation, and resulted in a single instance. As a consequence dependency injection and verticle factories were not something that we needed to be concerned about.

This PR switches to a worker verticle style that is multi-instance and provides a Spring based dependency injection aware verticle factory. The default worker pool size is now `core count * 2` and can be configured using the `omero.ms.backbone.worker_pool_size` OMERO server configuration property. Because of the OMERO server's dependency on Spring 3 the use of Java 8+ lambda expressions are not permitted in the directly accessible verticle code.