### PR TITLE
Hibernate event propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ distribution and placement in the `etc` folder of your OMERO instance
 1. Symlinking of the `omero-ms-backbone*.jar` to `extensions.jar` in order to
 activate the infrastructure
 
+1. (Optional) In order to enable the Hibernate Event listeners and propagate 
+events from Hibernate to HazelCast, the `BackBoneEventListener` needs to be 
+registered with Hibernate. To do this, it is necessary to edit the 
+`model-psql.jar` in the `lib/server` directory. Some tools (e.g. Vim) are 
+capable of editing the JAR in place, otherwise it is necessary to unpack, 
+edit, and re-zip the JAR. The following lines must be added to `hibernate.cfg
+.xml` within that JAR:
+```xml
+<listener type="post-collection-update" class="com.glencoesoftware.omero.ms.backbone.BackboneEventListener"/>
+<listener type="post-collection-remove" class="com.glencoesoftware.omero.ms.backbone.BackboneEventListener"/>
+```
+
 1. Restarting your OMERO server
 
 Configuring Logging

--- a/README.md
+++ b/README.md
@@ -35,17 +35,10 @@ distribution and placement in the `etc` folder of your OMERO instance
 1. Symlinking of the `omero-ms-backbone*.jar` to `extensions.jar` in order to
 activate the infrastructure
 
-1. (Optional) In order to enable the Hibernate Event listeners and propagate 
-events from Hibernate to HazelCast, the `BackBoneEventListener` needs to be 
-registered with Hibernate. To do this, it is necessary to edit the 
-`model-psql.jar` in the `lib/server` directory. Some tools (e.g. Vim) are 
-capable of editing the JAR in place, otherwise it is necessary to unpack, 
-edit, and re-zip the JAR. The following lines must be added to `hibernate.cfg
-.xml` within that JAR:
-```xml
-<listener type="post-collection-update" class="com.glencoesoftware.omero.ms.backbone.BackboneEventListener"/>
-<listener type="post-collection-remove" class="com.glencoesoftware.omero.ms.backbone.BackboneEventListener"/>
-```
+1. (Optional) Configuring `omero.ms.backbone.event_listeners` OMERO server
+configuration property with one or more of "INSERT", "UPDATE", and "DELETE" to
+enable the respective event listeners to propagate Hibernate events from OMERO
+to Hazelcast
 
 1. Restarting your OMERO server
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,9 @@ dependencies {
     compile 'io.vertx:vertx-web:3.6.3'
     compile 'io.vertx:vertx-hazelcast:3.6.3'
     compile 'io.vertx:vertx-health-check:3.6.3'
-    compile 'org.hibernate:hibernate-core:3.5.6-4510'
+    compile('org.hibernate:hibernate-core:3.5.6-4510') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     compileOnly('omero:blitz:5.4.10-ice36-b105') {
         exclude group: 'org.testng', module: 'testng'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compile 'io.vertx:vertx-web:3.6.3'
     compile 'io.vertx:vertx-hazelcast:3.6.3'
     compile 'io.vertx:vertx-health-check:3.6.3'
+    compile 'org.hibernate:hibernate-core:3.5.6-4510'
     compileOnly('omero:blitz:5.4.10-ice36-b105') {
         exclude group: 'org.testng', module: 'testng'
     }

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneEventListener.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneEventListener.java
@@ -2,34 +2,20 @@ package com.glencoesoftware.omero.ms.backbone;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import ome.model.IObject;
-import org.hibernate.HibernateException;
-import org.hibernate.event.AbstractCollectionEvent;
-import org.hibernate.event.PostCollectionRemoveEvent;
-import org.hibernate.event.PostCollectionRemoveEventListener;
-import org.hibernate.event.PostCollectionUpdateEvent;
-import org.hibernate.event.PostCollectionUpdateEventListener;
+import org.hibernate.event.PostDeleteEvent;
+import org.hibernate.event.PostDeleteEventListener;
 import org.hibernate.event.PostInsertEvent;
 import org.hibernate.event.PostInsertEventListener;
 import org.hibernate.event.PostUpdateEvent;
 import org.hibernate.event.PostUpdateEventListener;
-import org.hibernate.event.SaveOrUpdateEvent;
-import org.hibernate.event.SaveOrUpdateEventListener;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Map;
-
 public class BackboneEventListener implements
-        SaveOrUpdateEventListener,
         PostInsertEventListener,
         PostUpdateEventListener,
-        PostCollectionUpdateEventListener,
-        PostCollectionRemoveEventListener {
-
-    public static final String MODEL_CHANGE_EVENT = "ome.model.change";
+        PostDeleteEventListener {
 
     private static final org.slf4j.Logger log =
             LoggerFactory.getLogger(BackboneEventListener.class);
@@ -38,68 +24,40 @@ public class BackboneEventListener implements
 
     public BackboneEventListener() {
         super();
-        log.info("Registering BackboneEventListener...");
-        Vertx vertx = Vertx.vertx();
-        eventBus = vertx.eventBus();
-    }
-
-    @Override
-    public void onPostUpdateCollection(PostCollectionUpdateEvent postCollectionUpdateEvent) {
-        log.info("Collection updated!");
-        notifyCollectionChange(postCollectionUpdateEvent);
-    }
-
-    @Override
-    public void onPostRemoveCollection(PostCollectionRemoveEvent postCollectionRemoveEvent) {
-        log.info("Collection removed!");
-        notifyCollectionChange(postCollectionRemoveEvent);
-    }
-
-    private void notifyCollectionChange(AbstractCollectionEvent event) {
-        JsonArray changes = new JsonArray();
-
-        String ownerName = event.getAffectedOwnerEntityName();
-        Long ownerId = (Long) event.getAffectedOwnerIdOrNull();
-        log.info("Collection changed: {}({})", ownerName, ownerId);
-        JsonObject owner = new JsonObject();
-        owner.put("entityType", ownerName);
-        owner.put("entityId", ownerId);
-        changes.add(owner);
-
-        if (event.getCollection() instanceof Collection) {
-            Collection<?> entities =
-                    (Collection<?>) event.getCollection();
-            for (Object obj : entities) {
-                if (obj instanceof IObject) {
-                    IObject iobj = (IObject) obj;
-                    String entityName = iobj.getClass().getName();
-                    Long entityId = iobj.getId();
-                    log.info("Entity changed: {}({})", entityName, entityId);
-                    JsonObject entity = new JsonObject();
-                    entity.put("entityType", entityName);
-                    entity.put("entityId", entityId);
-                    changes.add(entity);
-                }
-            }
-        } else if (event.getCollection() instanceof Map) {
-            Map<?, ?> entityMap = (Map<?, ?>) event.getCollection();
-            log.info("Map changed: {}", entityMap.getClass());
-        }
-        eventBus.publish(MODEL_CHANGE_EVENT, changes);
-    }
-
-    @Override
-    public void onPostUpdate(PostUpdateEvent postUpdateEvent) {
-        log.info("Updated Entity: {}", postUpdateEvent.getEntity());
-    }
-
-    @Override
-    public void onSaveOrUpdate(SaveOrUpdateEvent saveOrUpdateEvent) throws HibernateException {
-        log.info("Save or Update of Entity: {}", saveOrUpdateEvent.getEntity());
+        eventBus = Vertx.vertx().eventBus();
     }
 
     @Override
     public void onPostInsert(PostInsertEvent postInsertEvent) {
-        log.info("Entity Inserted: {}", postInsertEvent.getEntity());
+        Object obj = postInsertEvent.getEntity();
+        log.debug("Insert event for entity: {}", obj);
+        publishEvent(obj, "insert");
+    }
+
+    @Override
+    public void onPostUpdate(PostUpdateEvent postUpdateEvent) {
+        Object obj = postUpdateEvent.getEntity();
+        log.debug("Update event for entity: {}", obj);
+        publishEvent(obj, "update");
+    }
+
+    @Override
+    public void onPostDelete(PostDeleteEvent postDeleteEvent) {
+        Object obj = postDeleteEvent.getEntity();
+        log.debug("Delete event for entity: {}", obj);
+        publishEvent(obj, "delete");
+    }
+
+    private void publishEvent(Object obj, String changeType) {
+        if (obj instanceof IObject) {
+            IObject iobj = (IObject) obj;
+            String entityType = iobj.getClass().getName();
+            Long entityId = iobj.getId();
+            JsonObject event = new JsonObject();
+            event.put("changeType", changeType);
+            event.put("entityType", entityType);
+            event.put("entityId", entityId);
+            eventBus.publish(BackboneVerticle.MODEL_CHANGE_EVENT, event);
+        }
     }
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneEventListener.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneEventListener.java
@@ -1,0 +1,74 @@
+package com.glencoesoftware.omero.ms.backbone;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import ome.model.IObject;
+import org.hibernate.event.AbstractCollectionEvent;
+import org.hibernate.event.PostCollectionRemoveEvent;
+import org.hibernate.event.PostCollectionRemoveEventListener;
+import org.hibernate.event.PostCollectionUpdateEvent;
+import org.hibernate.event.PostCollectionUpdateEventListener;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class BackboneEventListener implements
+        PostCollectionUpdateEventListener,
+        PostCollectionRemoveEventListener {
+
+    public static final String MODEL_CHANGE_EVENT = "ome.model.change";
+
+    private static final org.slf4j.Logger log =
+            LoggerFactory.getLogger(BackboneEventListener.class);
+
+    private EventBus eventBus;
+
+    public BackboneEventListener() {
+        super();
+        log.info("Registering BackboneEventListener...");
+        Vertx vertx = Vertx.vertx();
+        eventBus = vertx.eventBus();
+    }
+
+    @Override
+    public void onPostUpdateCollection(PostCollectionUpdateEvent postCollectionUpdateEvent) {
+        log.info("Collection updated!");
+        notifyCollectionChange(postCollectionUpdateEvent);
+    }
+
+    @Override
+    public void onPostRemoveCollection(PostCollectionRemoveEvent postCollectionRemoveEvent) {
+        log.info("Collection removed!");
+        // notifyCollectionChange(postCollectionRemoveEvent);
+    }
+
+    private void notifyCollectionChange(AbstractCollectionEvent event) {
+        JsonArray changes = new JsonArray();
+
+        String ownerName = event.getAffectedOwnerEntityName();
+        Long ownerId = (Long) event.getAffectedOwnerIdOrNull();
+        log.info("Collection changed: {}({})", ownerName, ownerId);
+        JsonObject owner = new JsonObject();
+        owner.put("entityType", ownerName);
+        owner.put("entityId", ownerId);
+        changes.add(owner);
+
+        Collection<?> entities =
+                (Collection<?>) event.getCollection();
+        for (Object obj : entities) {
+            if (obj instanceof IObject) {
+                IObject iobj = (IObject) obj;
+                String entityName = iobj.getClass().getName();
+                Long entityId = iobj.getId();
+                log.info("Entity changed: {}({})", entityName, entityId);
+                JsonObject entity = new JsonObject();
+                entity.put("entityType", entityName);
+                entity.put("entityId", entityId);
+                changes.add(entity);
+            }
+        }
+        eventBus.publish(MODEL_CHANGE_EVENT, changes);
+    }
+}

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneEventListener.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneEventListener.java
@@ -5,16 +5,27 @@ import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import ome.model.IObject;
+import org.hibernate.HibernateException;
 import org.hibernate.event.AbstractCollectionEvent;
 import org.hibernate.event.PostCollectionRemoveEvent;
 import org.hibernate.event.PostCollectionRemoveEventListener;
 import org.hibernate.event.PostCollectionUpdateEvent;
 import org.hibernate.event.PostCollectionUpdateEventListener;
+import org.hibernate.event.PostInsertEvent;
+import org.hibernate.event.PostInsertEventListener;
+import org.hibernate.event.PostUpdateEvent;
+import org.hibernate.event.PostUpdateEventListener;
+import org.hibernate.event.SaveOrUpdateEvent;
+import org.hibernate.event.SaveOrUpdateEventListener;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Map;
 
 public class BackboneEventListener implements
+        SaveOrUpdateEventListener,
+        PostInsertEventListener,
+        PostUpdateEventListener,
         PostCollectionUpdateEventListener,
         PostCollectionRemoveEventListener {
 
@@ -41,7 +52,7 @@ public class BackboneEventListener implements
     @Override
     public void onPostRemoveCollection(PostCollectionRemoveEvent postCollectionRemoveEvent) {
         log.info("Collection removed!");
-        // notifyCollectionChange(postCollectionRemoveEvent);
+        notifyCollectionChange(postCollectionRemoveEvent);
     }
 
     private void notifyCollectionChange(AbstractCollectionEvent event) {
@@ -55,20 +66,40 @@ public class BackboneEventListener implements
         owner.put("entityId", ownerId);
         changes.add(owner);
 
-        Collection<?> entities =
-                (Collection<?>) event.getCollection();
-        for (Object obj : entities) {
-            if (obj instanceof IObject) {
-                IObject iobj = (IObject) obj;
-                String entityName = iobj.getClass().getName();
-                Long entityId = iobj.getId();
-                log.info("Entity changed: {}({})", entityName, entityId);
-                JsonObject entity = new JsonObject();
-                entity.put("entityType", entityName);
-                entity.put("entityId", entityId);
-                changes.add(entity);
+        if (event.getCollection() instanceof Collection) {
+            Collection<?> entities =
+                    (Collection<?>) event.getCollection();
+            for (Object obj : entities) {
+                if (obj instanceof IObject) {
+                    IObject iobj = (IObject) obj;
+                    String entityName = iobj.getClass().getName();
+                    Long entityId = iobj.getId();
+                    log.info("Entity changed: {}({})", entityName, entityId);
+                    JsonObject entity = new JsonObject();
+                    entity.put("entityType", entityName);
+                    entity.put("entityId", entityId);
+                    changes.add(entity);
+                }
             }
+        } else if (event.getCollection() instanceof Map) {
+            Map<?, ?> entityMap = (Map<?, ?>) event.getCollection();
+            log.info("Map changed: {}", entityMap.getClass());
         }
         eventBus.publish(MODEL_CHANGE_EVENT, changes);
+    }
+
+    @Override
+    public void onPostUpdate(PostUpdateEvent postUpdateEvent) {
+        log.info("Updated Entity: {}", postUpdateEvent.getEntity());
+    }
+
+    @Override
+    public void onSaveOrUpdate(SaveOrUpdateEvent saveOrUpdateEvent) throws HibernateException {
+        log.info("Save or Update of Entity: {}", saveOrUpdateEvent.getEntity());
+    }
+
+    @Override
+    public void onPostInsert(PostInsertEvent postInsertEvent) {
+        log.info("Entity Inserted: {}", postInsertEvent.getEntity());
     }
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneService.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneService.java
@@ -38,9 +38,9 @@ import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
 import ome.system.PreferenceContext;
 import org.apache.commons.lang.ArrayUtils;
 import org.hibernate.event.EventListeners;
+import org.hibernate.event.PostDeleteEventListener;
 import org.hibernate.event.PostInsertEventListener;
 import org.hibernate.event.PostUpdateEventListener;
-import org.hibernate.event.SaveOrUpdateEventListener;
 import org.hibernate.impl.SessionFactoryImpl;
 import org.slf4j.LoggerFactory;
 
@@ -112,16 +112,14 @@ public class BackboneService {
         });
 
         log.debug("Registering Hibernate Event Listeners");
-        EventListeners eventListeners = sessionFactory.getEventListeners();
-        SaveOrUpdateEventListener[] listeners = eventListeners.getUpdateEventListeners();
-        log.debug("Existing update event listeners: {}", listeners.length);
-        BackboneEventListener eventListener = new BackboneEventListener();
-        eventListeners.setUpdateEventListeners((SaveOrUpdateEventListener[]) ArrayUtils.add(listeners, eventListener));
-        log.debug("Current update event listeners: {}",
-                sessionFactory.getEventListeners().getUpdateEventListeners().length);
-        eventListeners.setSaveEventListeners((SaveOrUpdateEventListener[]) ArrayUtils.add(eventListeners.getSaveEventListeners(), eventListener));
-        eventListeners.setPostUpdateEventListeners((PostUpdateEventListener[]) ArrayUtils.add(eventListeners.getPostUpdateEventListeners(), eventListener));
-        eventListeners.setPostInsertEventListeners((PostInsertEventListener[]) ArrayUtils.add(eventListeners.getPostInsertEventListeners(), eventListener));
+        EventListeners listeners = sessionFactory.getEventListeners();
+        BackboneEventListener listener = new BackboneEventListener();
+        listeners.setPostInsertEventListeners(
+                (PostInsertEventListener[]) ArrayUtils.add(listeners.getPostInsertEventListeners(), listener));
+        listeners.setPostUpdateEventListeners(
+                (PostUpdateEventListener[]) ArrayUtils.add(listeners.getPostUpdateEventListeners(), listener));
+        listeners.setPostDeleteEventListeners(
+                (PostDeleteEventListener[]) ArrayUtils.add(listeners.getPostDeleteEventListeners(), listener));
     }
 
     /**

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
@@ -237,6 +237,19 @@ public class BackboneVerticle extends AbstractVerticle {
                 };
             }
         );
+        eventBus.<JsonArray>consumer(
+                BackboneEventListener.MODEL_CHANGE_EVENT,
+                new Handler<Message<JsonArray>>() {
+                    public void handle(Message<JsonArray> changes) {
+                        for (Object change : changes.body()) {
+                            JsonObject changeObj = (JsonObject) change;
+                            log.info("OME Model Entity changed: {}(ID: {})",
+                                    changeObj.getString("entityName"),
+                                    changeObj.getLong("entityId"));
+                        }
+                    };
+                }
+        );
     }
 
     private void handleMessageWithJob(BackboneSimpleWork job) {

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
@@ -37,14 +37,12 @@ import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import ome.api.IMetadata;
 import ome.api.IPixels;
 import ome.api.IQuery;
 import ome.conditions.RemovedSessionException;
 import ome.conditions.SessionTimeoutException;
 import ome.io.nio.OriginalFilesService;
 import ome.model.IObject;
-import ome.model.annotations.Annotation;
 import ome.model.annotations.FileAnnotation;
 import ome.model.core.Image;
 import ome.model.core.OriginalFile;
@@ -237,16 +235,6 @@ public class BackboneVerticle extends AbstractVerticle {
                 public void handle(Message<JsonObject> event) {
                     getImportedImageFiles(event);
                 };
-            }
-        );
-        eventBus.<JsonObject>consumer(
-            MODEL_CHANGE_EVENT, new Handler<Message<JsonObject>>() {
-                public void handle(Message<JsonObject> event) {
-                    JsonObject change = event.body();
-                    log.debug("OME Model Entity changed: {}(ID: {})",
-                            change.getString("entityName"),
-                            change.getLong("entityId"));
-                }
             }
         );
     }

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/BackboneVerticle.java
@@ -21,7 +21,6 @@ package com.glencoesoftware.omero.ms.backbone;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.ObjectOutputStream;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -109,6 +108,9 @@ public class BackboneVerticle extends AbstractVerticle {
 
     public static final String GET_IMPORTED_IMAGE_FILES =
             "omero.get_imported_image_files";
+
+    public static final String MODEL_CHANGE_EVENT =
+            "ome.model.change";
 
     private final Executor executor;
 
@@ -237,18 +239,15 @@ public class BackboneVerticle extends AbstractVerticle {
                 };
             }
         );
-        eventBus.<JsonArray>consumer(
-                BackboneEventListener.MODEL_CHANGE_EVENT,
-                new Handler<Message<JsonArray>>() {
-                    public void handle(Message<JsonArray> changes) {
-                        for (Object change : changes.body()) {
-                            JsonObject changeObj = (JsonObject) change;
-                            log.info("OME Model Entity changed: {}(ID: {})",
-                                    changeObj.getString("entityName"),
-                                    changeObj.getLong("entityId"));
-                        }
-                    };
+        eventBus.<JsonObject>consumer(
+            MODEL_CHANGE_EVENT, new Handler<Message<JsonObject>>() {
+                public void handle(Message<JsonObject> event) {
+                    JsonObject change = event.body();
+                    log.debug("OME Model Entity changed: {}(ID: {})",
+                            change.getString("entityName"),
+                            change.getLong("entityId"));
                 }
+            }
         );
     }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/backbone/QueryVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/backbone/QueryVerticle.java
@@ -24,7 +24,6 @@ import java.io.ObjectInputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.lang.Integer;
 
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +44,6 @@ import io.vertx.ext.healthchecks.Status;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.spi.cluster.hazelcast.ClusterHealthCheck;
-import ome.model.annotations.FileAnnotation;
 import ome.model.core.Image;
 import ome.model.core.OriginalFile;
 import ome.model.core.Pixels;
@@ -126,9 +124,12 @@ public class QueryVerticle extends AbstractVerticle {
 
     private void consumeModelEvent(Message<JsonObject> event) {
         JsonObject change = event.body();
-        String name = change.getString("entityName");
-        Long id = change.getLong("entityID");
-        log.debug("OME Model Entity changed: {}(ID: {})", name, id);
+        String changeType = change.getString("changeType");
+        String entityType = change.getString("entityType");
+        Long entityId = change.getLong("entityId");
+        log.debug(
+            "OME Model Entity changeType: {} {}:{}",
+            changeType, entityType, entityId);
     }
 
     private <T> void ifFailed(

--- a/src/main/resources/ome/services/blitz-BackboneService.xml
+++ b/src/main/resources/ome/services/blitz-BackboneService.xml
@@ -12,6 +12,7 @@
   <bean id="omero-ms-backbone"
         class="com.glencoesoftware.omero.ms.backbone.BackboneService">
     <constructor-arg ref="preferenceContext"/>
+    <constructor-arg ref="sessionFactory"/>
     <constructor-arg ref="omero-ms-backbone-verticlefactory"/>
   </bean>
 

--- a/src/main/resources/ome/services/blitz-BackboneService.xml
+++ b/src/main/resources/ome/services/blitz-BackboneService.xml
@@ -28,6 +28,7 @@
 
   <bean id="omero-ms-backbone-event-listener"
         class="com.glencoesoftware.omero.ms.backbone.BackboneEventListener">
+    <constructor-arg ref="preferenceContext"/>
     <constructor-arg ref="sessionFactory"/>
   </bean>
 

--- a/src/main/resources/ome/services/blitz-BackboneService.xml
+++ b/src/main/resources/ome/services/blitz-BackboneService.xml
@@ -12,7 +12,6 @@
   <bean id="omero-ms-backbone"
         class="com.glencoesoftware.omero.ms.backbone.BackboneService">
     <constructor-arg ref="preferenceContext"/>
-    <constructor-arg ref="sessionFactory"/>
     <constructor-arg ref="omero-ms-backbone-verticlefactory"/>
   </bean>
 
@@ -25,6 +24,11 @@
     <constructor-arg ref="/OMERO/Files"/>
     <constructor-arg ref="managedRepository"/>
     <constructor-arg value="${omero.fs.repo.path_rules}"/>
+  </bean>
+
+  <bean id="omero-ms-backbone-event-listener"
+        class="com.glencoesoftware.omero.ms.backbone.BackboneEventListener">
+    <constructor-arg ref="sessionFactory"/>
   </bean>
 
 </beans>


### PR DESCRIPTION
Implements a separate verticle which doubles as a Hibernate event listener, the implementation of which simply takes the events sent by Hibernate and propagates them as JSON objects onto the Vert.X Hazelcast message bus.